### PR TITLE
ci(security): harden CI and add Dependabot scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '09:00'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    commit-message:
+      prefix: chore
+      include: scope
+    ignore:
+      # Major Node version bumps should be deliberate.
+      - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '09:00'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: ci
+      include: scope

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check-test-build:
     runs-on: ubuntu-latest
@@ -15,22 +18,25 @@ jobs:
       contents: read
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.33.2
           run_install: false
 
       - name: setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm
 
       - name: install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: audit dependencies
+        run: pnpm audit
 
       - name: check
         run: pnpm check
@@ -51,7 +57,7 @@ jobs:
 
       - name: upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-report
           path: coverage/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | :white_check_mark: |
+| < v0.1  | :x:                |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in monochange/actions, please report it
+discretely via GitHub Security Advisories:
+
+1. Go to the repository's **Security** tab.
+2. Click **Report a vulnerability**.
+3. Provide a clear description, reproduction steps, and impact assessment.
+
+We will acknowledge receipt within 48 hours and aim to provide a fix or
+timeline within 7 days.
+
+## Security Hardening
+
+This repository uses the following practices:
+
+- **Dependabot** is enabled for automated dependency updates.
+- **CI action versions are pinned** to full-length commit SHAs to mitigate
+  supply-chain attacks.
+- **Least-privilege workflow permissions** are applied where possible.
+- **`pnpm audit`** runs in CI to surface known vulnerabilities.
+
+## Disclosure Policy
+
+Once a fix is released, we will publicly disclose the issue via a GitHub
+Security Advisory and credit the reporter.


### PR DESCRIPTION
ci: security hardening — Dependabot, pnpm audit, pinned action SHAs

- Add Dependabot config for npm (pnpm) and GitHub Actions ecosystems
- Add SECURITY.md with reporting policy and supported versions
- Pin all third-party CI action references to immutable commit SHAs
  (actions/checkout, pnpm/action-setup, actions/setup-node,
   actions/upload-artifact) with trailing version comments
- Add top-level `permissions: contents: read` to CI workflow
- Add `pnpm audit` step after install in CI
- Add least-privilege `permissions` block on the CI job
